### PR TITLE
Use https instead of http for the maven takes repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ public final class App {
 }
 ```
 
-Then, download [`takes.jar`](http://repo1.maven.org/maven2/org/takes/takes/) and compile your Java code:
+Then, download [`takes.jar`](https://repo1.maven.org/maven2/org/takes/takes/) and compile your Java code:
 
 ```
 $ javac -cp takes.jar App.java


### PR DESCRIPTION
Hello,

When you visit the repository link in the current readme you will get the following error:

```
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```

So I changed the URL accordingly.